### PR TITLE
shift Quick install to the top

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,19 @@ An API compatible open source server for interacting with devices speaking the s
 </pre>
 
 
+Quick Install
+==============
+
+```
+git clone git@github.com:spark/spark-protocol.git
+git clone git@github.com:spark/spark-server.git
+cd spark-server/js
+npm install ../../spark-protocol/js
+npm install
+node main.js
+```
+
+
 How do I get started?
 =====================
 
@@ -62,19 +75,6 @@ Note!  The CLI will turn your PEM file into a DER file, but you can also do that
 
 ```
   spark list
-```
-
-
-Quick Install
-==============
-
-```
-git clone git@github.com:spark/spark-protocol.git
-git clone git@github.com:spark/spark-server.git
-cd spark-server/js
-npm install ../../spark-protocol/js
-npm install
-node main.js
 ```
 
 


### PR DESCRIPTION
Sequenced the docs flow to prevent confusion of running main.js without installing
