### PR TITLE
Add basic scripts to install/uninstall debian init.d scripts 

### DIFF
--- a/js/install-init-d.sh
+++ b/js/install-init-d.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+
+if [ "$(id -u)" != "0" ]; then
+  echo "Must be executed as root"
+  exit 1
+fi
+
+SPARK_HOME=$PWD
+SCRIPT_NAME=sparkup
+INIT_D_SCRIPT=/etc/init.d/$SCRIPT_NAME
+
+# First install forever
+hash forever &> /dev/null
+if [ $? -eq 1 ]; then
+    echo "forever not found. Installing..."
+    npm install -g forever
+else
+    echo "forever: installed and on the path."
+fi
+
+echo "Using $SPARK_HOME as Spark server home." 
+cat > $INIT_D_SCRIPT << EOF
+#!/bin/sh
+#$INIT_D_SCRIPT
+
+export PATH=$PATH:/usr/local/bin
+export NODE_PATH=$NODE_PATH:/usr/local/lib/node_modules
+
+case "\$1" in
+start)
+  exec forever --sourceDir=$SPARK_HOME -p /var/forever/pidetcfiles main.js
+  ;;
+stop)
+  exec forever stop --sourceDir=$SPARK_HOME main.js
+  ;;
+*)
+  echo "Usage: $INIT_D_SCRIPT {start|stop}"
+  exit 1
+  ;;
+esac
+
+exit 0
+EOF
+
+chmod 755 $INIT_D_SCRIPT
+
+update-rc.d $SCRIPT_NAME defaults

--- a/js/install-init-d.sh
+++ b/js/install-init-d.sh
@@ -9,6 +9,8 @@ SPARK_HOME=$PWD
 SCRIPT_NAME=sparkup
 INIT_D_SCRIPT=/etc/init.d/$SCRIPT_NAME
 
+FOREVER_WORKING_PATH=/var/spark
+
 # First install forever
 hash forever &> /dev/null
 if [ $? -eq 1 ]; then
@@ -28,10 +30,15 @@ export NODE_PATH=$NODE_PATH:/usr/local/lib/node_modules
 
 case "\$1" in
 start)
-  exec forever --sourceDir=$SPARK_HOME -p /var/forever/pidetcfiles main.js
+  exec forever start --sourceDir=$SPARK_HOME \
+    -p $FOREVER_WORKING_PATH \
+    -l $FOREVER_WORKING_PATH/forever.log \
+    -o $FOREVER_WORKING_PATH/spark-server.log \
+    -e $FOREVER_WORKING_PATH/spark-server.err.log \
+    main.js
   ;;
 stop)
-  exec forever stop --sourceDir=$SPARK_HOME main.js
+  exec forever stop --sourceDir=$SPARK_HOME -p $FOREVER_WORKING_PATH main.js
   ;;
 *)
   echo "Usage: $INIT_D_SCRIPT {start|stop}"
@@ -43,5 +50,7 @@ exit 0
 EOF
 
 chmod 755 $INIT_D_SCRIPT
+
+mkdir $FOREVER_WORKING_PATH
 
 update-rc.d $SCRIPT_NAME defaults

--- a/js/uninstall-init-d.sh
+++ b/js/uninstall-init-d.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+if [ "$(id -u)" != "0" ]; then
+  echo "Must be executed as root"
+  exit 1
+fi
+
+SCRIPT_NAME=sparkup
+INIT_D_SCRIPT=/etc/init.d/$SCRIPT_NAME
+
+$INIT_D_SCRIPT stop
+
+update-rc.d -f $SCRIPT_NAME remove
+
+rm $INIT_D_SCRIPT

--- a/js/uninstall-init-d.sh
+++ b/js/uninstall-init-d.sh
@@ -8,8 +8,11 @@ fi
 SCRIPT_NAME=sparkup
 INIT_D_SCRIPT=/etc/init.d/$SCRIPT_NAME
 
+FOREVER_WORKING_PATH=/var/spark
+
 $INIT_D_SCRIPT stop
 
 update-rc.d -f $SCRIPT_NAME remove
 
 rm $INIT_D_SCRIPT
+rm -rf $FOREVER_WORKING_PATH


### PR DESCRIPTION
Scripts to install an init.d script for starting the Spark server on boot. Fixes [issue 17](https://github.com/spark/spark-server/issues/17)

Usage (from `<spark-server-root>/js`): 

```
sudo ./install-init-d.sh
```

To uninstall:

```
sudo ./uninstall-init-d.sh
```

The user can then start/stop the server manually by using:

```
sudo /etc/init.d/sparkup start <or stop>
```

Logs are directed to files in `/var/spark`
