### PR TITLE
Fix link to raspberryPi.md in doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ npm install
 node main.js
 ```
 
-[Raspberry pi Quick Install](doc/raspberryPi.md)
+[Raspberry pi Quick Install](raspberryPi.md)
 
 
 How do I get started?


### PR DESCRIPTION
Fix wrong link to raspberryPi.md from README
