### PR TITLE
RasPi quick install was moved into "root"

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ npm install
 node main.js
 ```
 
-[Raspberry pi Quick Install](doc/raspberryPi.md)
+[Raspberry pi Quick Install](raspberryPi.md)
 
 
 How do I get started?


### PR DESCRIPTION
The original linke was brokeen
