### PR TITLE
Fix broken hash function

### DIFF
--- a/lib/PasswordHasher.js
+++ b/lib/PasswordHasher.js
@@ -29,7 +29,7 @@ PasswordHasher.generateSalt = function (callback) {
 PasswordHasher.hash = function (password, salt, callback) {
 	password = password.toString('base64');
 	salt = salt.toString('base64');
-	return crypto.pbkdf2(password, salt, 30000, 64, function (err, derivedKey) {
+	return crypto.pbkdf2(password, salt, 30000, 64, 'sha512', function (err, derivedKey) {
 		return callback(err, derivedKey.toString('base64'));
 	});
 };


### PR DESCRIPTION
Needed to add a "digest" key to the hash function to satisfy crypto.pbkdf2 otherwise the spark-server could not generate a user json config file. Now you can execute the following and you will get a bob.json file successfully:

curl -X POST http://192.168.1.50:8080/v1/users -d "username=bob" -d "password=123123"

:Doc:
crypto.pbkdf2(password, salt, iterations, keylen, digest, callback)